### PR TITLE
Fix the expected external database connection response format

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -644,6 +644,7 @@ const executeExternalQuery = async (
   // Build headers based on auth mode
   const headers: Record<string, string> = {
     "Content-Type": "application/x-www-form-urlencoded",
+    format: "JSONCompact",
   };
 
   if (connection.authMode === "api_key" && connection.apiKey) {


### PR DESCRIPTION
I'm not sure how this was originally tested as it would never have worked. The default response format of the httpserve extension is an array of objects while the code was expecting an array of arrays with a separate meta property for columns.

This PR requests the `JSONCompact` response from httpserve that matches this format which now makes external requests work.

https://github.com/ibero-data/duck-ui/issues/24