### PR TITLE
Support CDN loading for DuckDB WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker run -p 5522:5522 \
   ghcr.io/ibero-data/duck-ui:latest
 ```
 
-| Variable | Description | Default |
+| Runtime Variable | Description | Default |
 |----------|-------------|---------|
 | `DUCK_UI_EXTERNAL_CONNECTION_NAME` | Name for the external connection | "" |
 | `DUCK_UI_EXTERNAL_HOST` | Host URL for external DuckDB | "" |
@@ -50,8 +50,14 @@ docker run -p 5522:5522 \
 | `DUCK_UI_EXTERNAL_PASS` | Password for external connection | "" |
 | `DUCK_UI_EXTERNAL_DATABASE_NAME` | Database name for external connection | "" |
 | `DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS` | Allow unsigned extensions in DuckDB | false |
-| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Load DuckDB WASM from CDN | false |
+| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Load DuckDB WASM from CDN (ignored when build-time `DUCK_UI_DUCKDB_WASM_CDN_ONLY=true`) | false |
 | `DUCK_UI_DUCKDB_WASM_BASE_URL` | Custom CDN base URL (used when `DUCK_UI_DUCKDB_WASM_USE_CDN=true`) | auto jsDelivr |
+
+| Build-time Variable | Description | Default |
+|----------|-------------|---------|
+| `DUCK_UI_DUCKDB_WASM_CDN_ONLY` | Build a CDN-only artifact (local DuckDB WASM assets are not bundled). | false |
+
+When `DUCK_UI_DUCKDB_WASM_CDN_ONLY=true`, runtime `DUCK_UI_DUCKDB_WASM_USE_CDN=false` cannot switch back to local WASM.
 
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ docker run -p 5522:5522 \
 | `DUCK_UI_EXTERNAL_PASS` | Password for external connection | "" |
 | `DUCK_UI_EXTERNAL_DATABASE_NAME` | Database name for external connection | "" |
 | `DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS` | Allow unsigned extensions in DuckDB | false |
+| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Load DuckDB WASM from CDN | false |
+| `DUCK_UI_DUCKDB_WASM_BASE_URL` | Custom CDN base URL (used when `DUCK_UI_DUCKDB_WASM_USE_CDN=true`) | auto jsDelivr |
 
 
 

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -22,6 +22,8 @@ These variables allow you to configure Duck-UI to connect to an external DuckDB 
 | Variable | Description | Required | Default | Example |
 |----------|-------------|----------|---------|---------|
 | `DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS` | Allow loading unsigned DuckDB extensions | No | `false` | `"true"` |
+| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Enable loading DuckDB WASM and worker files from CDN | No | `false` | `"true"` |
+| `DUCK_UI_DUCKDB_WASM_BASE_URL` | Custom CDN base URL (when `DUCK_UI_DUCKDB_WASM_USE_CDN=true`) | No | Auto (`duckdb.getJsDelivrBundles()`) | `"https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev19.0/dist"` |
 
 ::: warning Security Note
 Enabling unsigned extensions may pose security risks. Only enable this in trusted environments.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -17,13 +17,21 @@ These variables allow you to configure Duck-UI to connect to an external DuckDB 
 | `DUCK_UI_EXTERNAL_PASS` | Password for authentication | No | `""` | `"your-password"` |
 | `DUCK_UI_EXTERNAL_DATABASE_NAME` | Database name to connect to | No | `""` | `"analytics"` |
 
-### Extension Settings
+### Runtime Settings
 
 | Variable | Description | Required | Default | Example |
 |----------|-------------|----------|---------|---------|
 | `DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS` | Allow loading unsigned DuckDB extensions | No | `false` | `"true"` |
-| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Enable loading DuckDB WASM and worker files from CDN | No | `false` | `"true"` |
+| `DUCK_UI_DUCKDB_WASM_USE_CDN` | Enable loading DuckDB WASM and worker files from CDN (ignored when `DUCK_UI_DUCKDB_WASM_CDN_ONLY=true` at build time) | No | `false` | `"true"` |
 | `DUCK_UI_DUCKDB_WASM_BASE_URL` | Custom CDN base URL (when `DUCK_UI_DUCKDB_WASM_USE_CDN=true`) | No | Auto (`duckdb.getJsDelivrBundles()`) | `"https://cdn.jsdelivr.net/npm/@duckdb/duckdb-wasm@1.33.1-dev19.0/dist"` |
+
+### Build-time Settings
+
+| Variable | Description | Required | Default | Example |
+|----------|-------------|----------|---------|---------|
+| `DUCK_UI_DUCKDB_WASM_CDN_ONLY` | Build a CDN-only artifact (local DuckDB WASM files are not bundled). Suitable for edge platforms with strict asset size limits. | No | `false` | `"true"` |
+
+When `DUCK_UI_DUCKDB_WASM_CDN_ONLY=true`, runtime `DUCK_UI_DUCKDB_WASM_USE_CDN=false` cannot switch back to local WASM because local assets are not included in the build.
 
 ::: warning Security Note
 Enabling unsigned extensions may pose security risks. Only enable this in trusted environments.

--- a/inject-env.js
+++ b/inject-env.js
@@ -16,7 +16,11 @@ const envVars = {
     process.env.DUCK_UI_EXTERNAL_DATABASE_NAME || "",
   // Add new configuration for DuckDB settings
   DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS:
-    process.env.DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS === "true" || false
+    process.env.DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS === "true" || false,
+  DUCK_UI_DUCKDB_WASM_USE_CDN:
+    process.env.DUCK_UI_DUCKDB_WASM_USE_CDN === "true" || false,
+  DUCK_UI_DUCKDB_WASM_BASE_URL:
+    process.env.DUCK_UI_DUCKDB_WASM_BASE_URL || ""
 };
 
 const scriptContent = `

--- a/src/services/duckdb/index.ts
+++ b/src/services/duckdb/index.ts
@@ -2,7 +2,7 @@
 // Extracted from the monolithic store for testability and modularity.
 
 export { rawResultToJSON, resultToJSON } from "./resultParser";
-export { initializeWasmConnection, loadEmbeddedDatabases, MANUAL_BUNDLES } from "./wasmConnection";
+export { initializeWasmConnection, loadEmbeddedDatabases, resolveDuckdbBundles } from "./wasmConnection";
 export { cleanupOPFSConnection, testOPFSConnection, opfsActivePaths } from "./opfsConnection";
 export {
   executeExternalQuery,

--- a/src/services/duckdb/opfsConnection.ts
+++ b/src/services/duckdb/opfsConnection.ts
@@ -61,7 +61,7 @@ export const testOPFSConnection = async (
     );
   }
 
-  const bundles = resolveDuckdbBundles();
+  const bundles = await resolveDuckdbBundles();
   const bundle = await duckdb.selectBundle(bundles);
   const { worker, revoke } = createDuckdbWorker(bundle.mainWorker!);
   const logger = new duckdb.VoidLogger();

--- a/src/services/persistence/systemDb.ts
+++ b/src/services/persistence/systemDb.ts
@@ -62,7 +62,7 @@ export async function initializeSystemDb(): Promise<void> {
   try {
     console.info("[SystemDB] Initializing system database (OPFS)...");
 
-    const bundles = resolveDuckdbBundles();
+    const bundles = await resolveDuckdbBundles();
     const bundle = await duckdb.selectBundle(bundles);
     const { worker, revoke } = createDuckdbWorker(bundle.mainWorker!);
     const logger = new duckdb.VoidLogger();

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -15,6 +15,8 @@ declare global {
       DUCK_UI_EXTERNAL_PASS: string;
       DUCK_UI_EXTERNAL_DATABASE_NAME: string;
       DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS: boolean;
+      DUCK_UI_DUCKDB_WASM_USE_CDN?: boolean;
+      DUCK_UI_DUCKDB_WASM_BASE_URL?: string;
     };
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 declare const __DUCK_UI_VERSION__: string;
 declare const __DUCK_UI_RELEASE_DATE__: string;
+declare const __DUCK_UI_BUILD_DUCKDB_CDN_ONLY__: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
+  const buildDuckdbCdnOnly = env.DUCK_UI_DUCKDB_WASM_CDN_ONLY === 'true';
 
   // Manually construct the object to be defined
   // Filter out keys with invalid JS identifier characters (fixes Windows builds where
@@ -28,6 +29,7 @@ export default defineConfig(({ mode }) => {
     define: {
       __DUCK_UI_VERSION__: JSON.stringify(pkg.version),
       __DUCK_UI_RELEASE_DATE__: JSON.stringify(pkg.release_date),
+      __DUCK_UI_BUILD_DUCKDB_CDN_ONLY__: JSON.stringify(buildDuckdbCdnOnly),
       ...processEnvValues // Spread the processed variables
     },
   };


### PR DESCRIPTION
This PR introduces a configurable mechanism for loading DuckDB WASM and worker assets, enabling both local and CDN-based deployments.

Key changes:

- Replace the static `MANUAL_BUNDLES` with `resolveDuckdbBundles`, which determines asset sources at runtime based on environment variables.
- Add support for CDN-based loading via:
  - `DUCK_UI_DUCKDB_WASM_USE_CDN`
  - `DUCK_UI_DUCKDB_WASM_BASE_URL`
- Introduce a build-time flag `DUCK_UI_DUCKDB_WASM_CDN_ONLY`, exposed as `__DUCK_UI_BUILD_DUCKDB_CDN_ONLY__` in Vite, to allow CDN-only builds.
- Add `createDuckdbWorker` to standardize worker instantiation (including proper URL revocation) and update all DuckDB connection paths to use it.
- Update environment variable documentation and typings accordingly.

There are no changes to query behavior. This update focuses on making DuckDB WASM asset loading configurable and better suited for edge deployments.