### PR TITLE
Enable support for pre-configured connections via env vars for httpserver compatible external servers deployed on subpaths (and also support auth using X-API-Key headers)

### DIFF
--- a/.github/workflows/2-docker-build.yml
+++ b/.github/workflows/2-docker-build.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta

--- a/.github/workflows/2-docker-build.yml
+++ b/.github/workflows/2-docker-build.yml
@@ -14,6 +14,7 @@ on:
     paths-ignore:
       - '**.md'
       - 'docs/**'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/2-docker-build.yml
+++ b/.github/workflows/2-docker-build.yml
@@ -60,5 +60,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DUCK_UI_BASEPATH=${{ vars.DUCK_UI_BASEPATH || '/' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN bun install --frozen-lockfile
 COPY . .
 
 # Build the app
-RUN bun run build
+RUN DUCK_UI_BASEPATH=${DUCK_UI_BASEPATH} bun run build
 
 # Use a second stage to reduce image size
 FROM oven/bun:1-alpine
@@ -43,6 +43,7 @@ ENV DUCK_UI_EXTERNAL_HOST=""
 ENV DUCK_UI_EXTERNAL_PORT=""
 ENV DUCK_UI_EXTERNAL_USER=""
 ENV DUCK_UI_EXTERNAL_PASS=""
+ENV DUCK_UI_EXTERNAL_API_KEY=""
 ENV DUCK_UI_EXTERNAL_DATABASE_NAME=""
 
 # Create user and change ownership

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ Open your browser and navigate to `http://localhost:5522`.
 You can customize Duck-UI behavior using environment variables:
 
 ```bash
-# For external DuckDB connections
+# For external DuckDB connections (API key auth)
+docker run -p 5522:5522 \
+  -e DUCK_UI_EXTERNAL_CONNECTION_NAME="My DuckDB Server" \
+  -e DUCK_UI_EXTERNAL_HOST="https://duckdb-server/duckdb" \
+  -e DUCK_UI_EXTERNAL_PORT="443" \
+  -e DUCK_UI_EXTERNAL_API_KEY="your-api-key" \
+  ghcr.io/caioricciuti/duck-ui:latest
+
+# For external DuckDB connections (username/password auth)
 docker run -p 5522:5522 \
   -e DUCK_UI_EXTERNAL_CONNECTION_NAME="My DuckDB Server" \
   -e DUCK_UI_EXTERNAL_HOST="http://duckdb-server" \
@@ -44,10 +52,11 @@ docker run -p 5522:5522 \
 | Runtime Variable | Description | Default |
 |----------|-------------|---------|
 | `DUCK_UI_EXTERNAL_CONNECTION_NAME` | Name for the external connection | "" |
-| `DUCK_UI_EXTERNAL_HOST` | Host URL for external DuckDB | "" |
+| `DUCK_UI_EXTERNAL_HOST` | Host URL for external DuckDB (may include path, e.g. `https://host/duckdb`) | "" |
 | `DUCK_UI_EXTERNAL_PORT` | Port for external DuckDB | null |
-| `DUCK_UI_EXTERNAL_USER` | Username for external connection | "" |
-| `DUCK_UI_EXTERNAL_PASS` | Password for external connection | "" |
+| `DUCK_UI_EXTERNAL_API_KEY` | API key sent as `X-API-Key` header (takes priority over user/password) | "" |
+| `DUCK_UI_EXTERNAL_USER` | Username for Basic auth (used when no API key is set) | "" |
+| `DUCK_UI_EXTERNAL_PASS` | Password for Basic auth | "" |
 | `DUCK_UI_EXTERNAL_DATABASE_NAME` | Database name for external connection | "" |
 | `DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS` | Allow unsigned extensions in DuckDB | false |
 | `DUCK_UI_DUCKDB_WASM_USE_CDN` | Load DuckDB WASM from CDN (ignored when build-time `DUCK_UI_DUCKDB_WASM_CDN_ONLY=true`) | false |
@@ -163,6 +172,44 @@ The output will be in the `dist` directory.
 - `Cmd/Ctrl + K`: Open Search Bar
 - `Cmd/Ctrl + Enter`: Run Query
 - `Cmd/Ctrl + Shift + Enter`: Run highlighted query
+
+## Deploying behind a reverse proxy
+
+When serving Duck-UI behind a two-layer nginx proxy (inner proxy + outer TLS/HTTP2 terminator such as [nginx-proxy](https://github.com/nginx-proxy/nginx-proxy)), you **must** suppress `Accept-Encoding` on the upstream connection to the Duck-UI container.
+
+`bun serve` natively compresses responses when it sees `Accept-Encoding: gzip`. That chunked-gzip stream causes `ERR_HTTP2_PROTOCOL_ERROR` when the outer proxy converts it to HTTP/2 DATA frames, making the page appear to hang after loading the first few assets.
+
+**Required inner-nginx config:**
+
+```nginx
+# Assets: no auth, raw bytes — outer proxy handles compression over HTTP/2
+location /ui/assets/ {
+    proxy_set_header Accept-Encoding "";
+    proxy_pass http://duck-ui:5522/assets/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Main app: basic auth gates index.html (which carries the pre-configured API key)
+location /ui/ {
+    auth_basic "Duck UI";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+    proxy_set_header Accept-Encoding "";
+    proxy_redirect http://duck-ui:5522 /ui/;
+    proxy_pass http://duck-ui:5522/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+Key points:
+- Do **not** add `gzip on` or `proxy_buffering on` to the Duck-UI locations in the inner proxy — the outer TLS terminator handles that
+- Split `/ui/assets/` (no auth) from `/ui/` (auth) so Web Workers can load WASM and JS without hitting an auth challenge
+- When building the image for a sub-path, pass `DUCK_UI_BASEPATH=/ui/` as a Docker build argument
 
 ## Contributing
 

--- a/inject-env.js
+++ b/inject-env.js
@@ -12,6 +12,7 @@ const envVars = {
   DUCK_UI_EXTERNAL_PORT: process.env.DUCK_UI_EXTERNAL_PORT || null,
   DUCK_UI_EXTERNAL_USER: process.env.DUCK_UI_EXTERNAL_USER || "",
   DUCK_UI_EXTERNAL_PASS: process.env.DUCK_UI_EXTERNAL_PASS || "",
+  DUCK_UI_EXTERNAL_API_KEY: process.env.DUCK_UI_EXTERNAL_API_KEY || "",
   DUCK_UI_EXTERNAL_DATABASE_NAME:
     process.env.DUCK_UI_EXTERNAL_DATABASE_NAME || "",
   // Add new configuration for DuckDB settings

--- a/src/services/duckdb/externalConnection.ts
+++ b/src/services/duckdb/externalConnection.ts
@@ -19,12 +19,23 @@ const buildConnectionUrl = (host: string, port?: string | number): string => {
   if (!url.startsWith("http://") && !url.startsWith("https://")) {
     url = `https://${url}`;
   }
-  // Only append port when the hostname portion doesn't already contain one.
-  // Strip the scheme first so the ":" in "https://" isn't matched.
+  // Use URL API to detect existing port on the hostname only (not the path).
   if (port) {
-    const hostWithoutScheme = url.replace(/^https?:\/\//, "");
-    if (!hostWithoutScheme.includes(":")) {
-      url = `${url}:${port}`;
+    try {
+      const parsed = new URL(url);
+      if (!parsed.port) {
+        parsed.port = String(port);
+        url = parsed.toString();
+      } else {
+        url = parsed.toString();
+      }
+    } catch {
+      // Fallback: strip scheme, check for colon before any slash
+      const withoutScheme = url.replace(/^https?:\/\//, "");
+      const hostPart = withoutScheme.split("/")[0];
+      if (!hostPart.includes(":")) {
+        url = `${url}:${port}`;
+      }
     }
   }
   if (!url.endsWith("/")) {

--- a/src/store/slices/duckdbSlice.ts
+++ b/src/store/slices/duckdbSlice.ts
@@ -33,6 +33,7 @@ export const createDuckdbSlice: StateCreator<
       DUCK_UI_EXTERNAL_PORT: externalPort = "",
       DUCK_UI_EXTERNAL_USER: externalUser = "",
       DUCK_UI_EXTERNAL_PASS: externalPass = "",
+      DUCK_UI_EXTERNAL_API_KEY: externalApiKey = "",
       DUCK_UI_EXTERNAL_DATABASE_NAME: externalDatabaseName = "",
     } = window.env || {};
 
@@ -55,8 +56,9 @@ export const createDuckdbSlice: StateCreator<
         port: Number(externalPort),
         user: externalUser,
         password: externalPass,
+        apiKey: externalApiKey,
         database: externalDatabaseName,
-        authMode: "password",
+        authMode: externalApiKey ? "api_key" : externalUser ? "password" : "none",
       });
     }
 

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -13,6 +13,7 @@ declare global {
       DUCK_UI_EXTERNAL_PORT: string;
       DUCK_UI_EXTERNAL_USER: string;
       DUCK_UI_EXTERNAL_PASS: string;
+      DUCK_UI_EXTERNAL_API_KEY: string;
       DUCK_UI_EXTERNAL_DATABASE_NAME: string;
       DUCK_UI_ALLOW_UNSIGNED_EXTENSIONS: boolean;
       DUCK_UI_DUCKDB_WASM_USE_CDN?: boolean;


### PR DESCRIPTION
# Background

Consider deploying duck-ui on a subpath on a server such as https://some-server.org/ui/ (so it is located next to other services on the server alleviating CORS issues where this server may be running a httpserver-"compatible" endpoint ... which may be deployed in a subpath).

The index page for duck-ui can then be located behind HTTP Basic auth in order to protect it for public access while duck-ui can use pre-set environment variables to enable convenient connection over the httpserver "protocol"/conventions (assuming the server has this capacity). 

In that case, the index.html is the only file that needs guarding — it carries a pre-injected window.env block containing a service-account API key for example for a caddy-duckdb backend which provides a httpserver compatible endpoint with X-API-Key headers auth. Static assets (/ui/assets/) are served without auth so that Web Workers can load the DuckDB WASM bundle without hitting an auth challenge.

On first load, duck-ui reads the env vars injected at container startup and automatically configures an external connection to https://some-server.org/duckdb/ using the service-account key. The user never sees or enters credentials — Basic auth gates the page itself, and the pre-configured key handles all SQL traffic.

This kind of deloyment of duck-ui can have two proxy layers on the server side (for example if nginx is used and nginx-proxy automatically handles termination of TLS):

```bash
  Browser
    │  HTTPS + Basic auth (letmein:letmein)
    ▼
  nginx-proxy  (TLS termination, HTTP/2)
    │  HTTP/1.1
    ▼
  nginx:alpine  (inner proxy, proxy.conf)
    ├── /ui/            → duck-ui:5522/       (Basic auth, Accept-Encoding: "")
    ├── /ui/assets/     → duck-ui:5522/assets/ (no auth,   Accept-Encoding: "")
    └── /duckdb/        → caddy-duckdb:8080/duckdb/
            ▲
            └── duck-ui fetches here with X-API-Key (same-origin, no CORS)
```

Before this PR there were two blockers:

1. No API-key env var. The only env-var auth path was DUCK_UI_EXTERNAL_USER / DUCK_UI_EXTERNAL_PASS (HTTP Basic). There was no way to pre-configure an X-API-Key header at container startup. Users had to manually add an external connection in the UI and type credentials. DUCK_UI_EXTERNAL_API_KEY didn't exist in either inject-env.js, duckdbSlice.ts, or the connection request headers.

2. buildConnectionUrl path+port bug. The host string needed to include a path (https://some-server.org/duckdb) because the DuckDB endpoint isn't at the root. The old URL-builder stripped the scheme, then checked for : in the remainder to detect an existing port — but /duckdb contains no :, so it would append :443 after the path, producing https://some-server.org/duckdb:443/ (an invalid URL). The workaround was to embed the port directly in the host string as https://some-server.org:443/duckdb, which is fragile and non-obvious. The fix uses new URL() to isolate the hostname before port detection.

## Summary

- **`DUCK_UI_EXTERNAL_API_KEY`**: new runtime env var that sets the `X-API-Key` header on external connections, taking priority over username/password auth. Useful when connecting to API-key-authenticated DuckDB backends (e.g. caddy-duckdb-module).
- **`buildConnectionUrl` fix**: uses the URL API to correctly handle host strings that include a path component (e.g. `https://host/duckdb`), preventing the port from being appended after the path.
- **Reverse-proxy deployment guide**: documents the `proxy_set_header Accept-Encoding ""` requirement when serving behind a two-layer nginx setup. Without this, bun's native chunked-gzip causes `ERR_HTTP2_PROTOCOL_ERROR` for the JS bundle on HTTP/2 connections.
- **CI**: switch `2-docker-build.yml` from `GHCR_PAT` to `GITHUB_TOKEN` — no manual secret needed, scoped to the workflow run.

## Changed files

| File | Change |
|------|--------|
| `src/store/slices/duckdbSlice.ts` | read `DUCK_UI_EXTERNAL_API_KEY` from `window.env`, set `authMode: "api_key"` |
| `src/store/types.ts` | add `apiKey` field to `ConnectionProvider` |
| `src/services/duckdb/externalConnection.ts` | send `X-API-Key` header when `authMode === "api_key"`; fix `buildConnectionUrl` URL parsing |
| `inject-env.js` | expose `DUCK_UI_EXTERNAL_API_KEY` in `window.env` |
| `Dockerfile` | declare `DUCK_UI_EXTERNAL_API_KEY` env var |
| `README.md` | document new env var, add reverse-proxy deployment section |
| `.github/workflows/2-docker-build.yml` | use `GITHUB_TOKEN` instead of `GHCR_PAT` |

## Test plan

- [x] `docker run` with `DUCK_UI_EXTERNAL_API_KEY` set — external connection shows as `api_key` auth mode and sends `X-API-Key` header
- [x] `docker run` with `DUCK_UI_EXTERNAL_USER`/`DUCK_UI_EXTERNAL_PASS` only — falls back to Basic auth
- [x] Host string with path (e.g. `https://host/duckdb`) — port no longer appended after path
- [x] Build and push via `2-docker-build.yml` workflow on push to `main` — image lands at `ghcr.io/username/duck-ui:latest`